### PR TITLE
README.md doesn't work as written, base_url needs to have /api/ appen…

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ use CommerceGuys\Guzzle\Oauth2\GrantType\PasswordCredentials;
 use CommerceGuys\Guzzle\Oauth2\Oauth2Subscriber;
 
 $oauth2Client = new Client([
-    'base_url' => 'http://demo.sylius.org',
+    'base_url' => 'http://demo.sylius.org/api/',
 ]);
 
 $config = [


### PR DESCRIPTION
…ded.

Ran into an issue based on README, the error was:
```
  Client error response [url] http://127.0.0.1:8000/oauth/v2/token [status code] 404 [reason phrase] Not Found  
```

Appending '/api/' to the base_url fixes it.